### PR TITLE
Dialoge angepasst (bzgl. des Kundenmeetings 05.01.)

### DIFF
--- a/dialogs/note_dialog.dialogue
+++ b/dialogs/note_dialog.dialogue
@@ -6,9 +6,8 @@
 => END
 
 ~ Note_1_Level
-Du hast ein Fragment gefunden.
 § 4
-	Möge der Prüfling die <Leertaste> drücken, um weiterzulesen.
+	Möge der Prüfling die <Leertaste> oder die <Linke Maustaste> drücken, um weiterzulesen.
 	Seine Agilität kann der Prüfling mithilfe von <W>, <A>, <S> und <D> unter Beweis stellen.
 	Dem Prüfling ist es jederzeit gestattet, mit <ESC> eine Rast einzulegen.
 	Auf diesem Weg soll er sich ebenfalls die Steuerung ins Gedächtnis rufen.
@@ -25,11 +24,9 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_2_Level
-Du hast ein Fragment gefunden.
 § 5
 	Auf dem Prüfgelände mögen Türen und Schlüssel verteilt sein.
 	Möge sich dabei jeder Schlüssel sich in einer eigenen Truhe befinden und nur auf eine Tür passen. 
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_2_Hub
@@ -40,12 +37,10 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_3_Level
-Du hast ein Fragment gefunden.
 § 6
 	Mögen die Gefahren des Labyrinths beginnen, sobald er die erste Tür durchschreitet. 
 	Der Prüfling möge den Gegnern und Hindernissen selbstständig ausweichen,
 	und so Intelligenz und Agilität zu beweisen.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_3_Hub
 --Aufestelltes Kodex-Fragment--
@@ -56,13 +51,11 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_4_Level
-Du hast ein Fragment gefunden.
 § 7
 	Sollte der Prüfling in einem Level des Labyrinths scheitern oder unterbrechen,
 	so muss er den besagten Abschnitt von vorne beginnen.
 	Mögen die Gegenstände des Levels erneut vom Prüfling gesammelt werden,
 	aber bereits erkundete Wege ihm bekannt erscheinen.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_4_Hub
 --Aufestelltes Kodex-Fragment--
@@ -74,7 +67,6 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_5_Level
-Du hast ein Fragment gefunden.
 § 8
 	Der Prüfling muss sich die gefundenen Fragmente im Laufe des Levels einprägen.
 	Möge er sein Gedächtnis in Rätseln unter Beweis stellen, um das Level abzuschließen.
@@ -90,11 +82,9 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_6_Level
-Du hast ein Fragment gefunden.
 § 9
 	Möge der Prüfling sich nach einem bestandenem Level unverzüglich zurück zum Hub begeben.
 	Möge er dort rasten, bis er wieder bei vollen Kräften ist, und von Trankeffekten ausgenüchtert ist.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_6_Hub
 --Aufestelltes Kodex-Fragment--
@@ -104,11 +94,9 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_7_Level
-Du hast ein Fragment gefunden.
 § 10
 	Der Prüfling kann mittels <M> auf die Zehenspitzen gehen und auf bereits erkundete Wege herabblicken.
 	Allerdings möge er dies nur versuchen, wenn sein Schwierigkeitsgrad es gestattet.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_7_Hub
 --Aufestelltes Kodex-Fragment--
@@ -119,11 +107,9 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 
 
 ~ Note_8_Level
-Du hast ein Fragment gefunden.
 § 11
 	Möge der Prüfling die Bewegungsmuster der Gegner observieren.
 	Gegner patrouillieren fest auf einer Linie oder zufällig in einem Bereich.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_8_Hub
 --Aufestelltes Kodex-Fragment--
@@ -133,12 +119,10 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_9_Level
-Du hast ein Fragment gefunden.
 § 12
 	Möge der Prüfling die Reaktionen der verschiedenen Fallen austesten.
 	Manche Fallen reagieren nur in einem bestimmten Sichtfeld.
 	Die Ruhephasen bis zum erneuten Auslösen unterscheiden sich von Falle zu Falle.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_9_Hub
 --Aufestelltes Kodex-Fragment--
@@ -148,10 +132,8 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_10_Level
-Du hast ein Fragment gefunden.
 § 13
 	Möge der Prüfling im letzten Level der Prüfung einen diamantenen Schlüssel für die finale Tür im Hub erhalten.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_10_Hub
 --Aufestelltes Kodex-Fragment--
@@ -160,11 +142,9 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_11_Level
-Du hast ein Fragment gefunden.
 § 14
 	Die Kodex-Fragmente können dem Prüfling nur zusammen ihre volle Weisheit offenbaren.
 	Möge der Prüfling in seinem letzten Rätsel seine Fähigkeiten in der Kombinatorik zeigen.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_11_Hub
 --Aufestelltes Kodex-Fragment--
@@ -174,13 +154,11 @@ Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 
 ~ Note_12_Level
-Du hast ein Fragment gefunden.
 § 15
 	Sollte der Prüfling nicht mehr aus dem Labyrinth finden,
 	so möge er dort in bis ans Ende seiner Tage in den Gängen umherirren.
 	Mögen seine Knochen selbst nach seinem Tod ihre gewohnten Wege patrouillieren
 	und Teil des Labyrinths werden.
-Gefundene Fragmente werden im rechten Raum des Hubs ausgestellt.
 => END
 ~ Note_12_Hub
 --Aufestelltes Kodex-Fragment--
@@ -208,7 +186,7 @@ Du findest einen Schildtrank.
 ~ Silberne_Kiste
 Du findest einen silbernen Schlüssel mit der Nummer {{Inventory.dialogue_temp_silver_id}}.
 	Mit ihm kannst du die zugehörige Tür in diesem Level öffnen.
-	Bereits gefundene silberne Schlüssel werden für die Dauer des Levels unten links eingeblendet.
+	Bereits gefundene silberne Schlüssel werden für die Dauer des Levels unten rechts eingeblendet.
 => END
 
 ~ Silberne_Kiste_negative
@@ -216,7 +194,7 @@ Du findest einen silbernen Schlüssel mit der Nummer {{Inventory.dialogue_temp_s
 => END
 
 ~ Goldene_Kiste_Teil1
-Löse das Rätsel der Truhe.
+Löse das Rätsel der Truhe, nachdem du alle Notes im Level gesammelt hast.
 	Erst danach wird sie ihren Inhalt freigeben.
 => END
 


### PR DESCRIPTION
- goldene truhe im hub - "du musst alle notes gesammelt haben" nach öffnen - in dialog: "silberne schlüssel werden unten links eingeblendet" - zu unten rechts ändern - dialoge: - leertaste direkt in der ersten note sagen